### PR TITLE
Compatible with Objective-C

### DIFF
--- a/Pod/Source/STLocationRequestController.swift
+++ b/Pod/Source/STLocationRequestController.swift
@@ -70,7 +70,7 @@ import Font_Awesome_Swift
 // MARK: - STLocationRequestController
 
 /// STLocationRequest is a UIViewController-Extension which is used to request the User-Location, at the very first time, in a simple and elegent way. It shows a beautiful 3D 360 degree Flyover-MapView which shows 14 random citys or landmarks.
-@objc public class STLocationRequestController: UIViewController {
+@objcMembers public class STLocationRequestController: UIViewController {
 
     // MARK: - (API) Public properties
     


### PR DESCRIPTION
declared the STLocationRequestController with @objcMembers rather than @objc since Swift v4.0